### PR TITLE
fix(memberships): lowercased email as PK

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -51,8 +51,10 @@ export const memberships = pgTable(
     guildId: text("guild_id")
       .references(() => guilds.guildId)
       .notNull(),
-    /** The email of the member */
+    /** The lowercased-email of the member */
     email: text("email"),
+    /** The email of the member, with the case specified when signing up. */
+    casedEmail: text("cased_email"),
     /** The phone number */
     phone: text("phone"),
     /** The name of the member */

--- a/src/services/memberships.service.ts
+++ b/src/services/memberships.service.ts
@@ -273,7 +273,8 @@ export class MembershipsService {
             }`,
             start_date: entry.joined_date,
             type: entry.type,
-            email: entry.email,
+            email: entry.email.toLowerCase(),
+            casedEmail: entry.email,
             phone: entry.mobile,
             userId: null,
           })
@@ -284,6 +285,7 @@ export class MembershipsService {
               name: `${entry.preferred_name ?? entry.first_name} ${
                 entry.last_name
               }`,
+              casedEmail: entry.email,
               phone: entry.mobile,
               type: entry.type,
             },


### PR DESCRIPTION
Uses lowercased emails to identify users, but respects the case they submitted by storing it alongside.